### PR TITLE
운영진 명단 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,8 +270,8 @@ permalink: /index.html
             <tr><td>2023년 2학기</td><td>나정휘(jhnah917)</td><td>박찬솔(chansol), 안해성(i_am_commang), 유상원(sangwon090)</td><td rowspan="2">나정휘(jhnah917)</td></tr>
             <tr><td>2023년 1학기</td><td>박찬솔(chansol)</td><td>나정휘(jhnah917)</td></tr>
             <tr><td>2022년</td><td>나정휘(jhnah917)</td><td>이영재(Rose)</td><td>이로건(logeon0725)</td></tr>
-            <tr><td>2021년</td><td>이영재(Rose)</td><td>김민후(marona)</td><td>이로건(logeon0725)</td></tr>
-            <tr><td>2020년</td><td>정종인(chongin12)</td><td></td><td></td></tr>
+            <tr><td>2021년</td><td>이영재(Rose)</td><td>이로건(logeon0725)</td><td>이로건(logeon0725)</td></tr>
+            <tr><td>2020년</td><td>정종인(chongin12)</td><td>김민후(marona)</td><td>이로건(logeon0725)</td></tr>
             <tr><td>2019년</td><td>권욱제(wookje)</td><td>주영준(king7282)</td><td></td></tr>
             <tr><td>2018년</td><td>이효빈(hyo123bin)</td><td>진소정</td><td>문태진</td></tr>
             <tr><td>2017년</td><td>유영정(youngjeong_yu)</td><td>김민후(marona), 윤태원</td><td>진소정</td></tr>


### PR DESCRIPTION
2020, 2021년도 운영진 명단이 잘못되어 있어 수정합니다.

2021 회장 이영재 부회장 김민후 총무 이로건
2020 회장 정종인 
->
2021 회장 이영재 부회장 이로건 총부 이로건
2020 회장 정종인 부회장 김민우 총무 이로건